### PR TITLE
feat: Update Product quantity in database after dispense

### DIFF
--- a/ExpoExtractor/Planogram.cs
+++ b/ExpoExtractor/Planogram.cs
@@ -1,0 +1,12 @@
+﻿namespace Filuet.Hardware.Dispenser
+{
+    public class Planogram
+    {
+        public string KioskName { get; set; }
+        public string ClientName { get; set; }
+        public int MachineId { get; set; }
+        public int TrayId { get; set; }
+        public int BeltId { get; set; }
+
+    }
+}

--- a/ExpoExtractor/appsettings.Development.json
+++ b/ExpoExtractor/appsettings.Development.json
@@ -4,5 +4,7 @@
       "Default": "Information",
       "Microsoft.AspNetCore": "Warning"
     }
-  }
+  },
+  "KioskCredentialPath": "@\"C:\\KioskCredentials\\Keys.json\"",
+  "PlanogramDatabaseUpdateUrl": "http://localhost:5002/api/planogram/dispense/"
 }

--- a/ExpoExtractor/appsettings.json
+++ b/ExpoExtractor/appsettings.json
@@ -13,5 +13,7 @@
     }
   },
   "AllowedHosts": "*",
-  "PlanogramPath": "C:/Filuet/Dispensing/test_planogram.json"
+  "PlanogramPath": "C:/Filuet/Dispensing/test_planogram.json",
+  "KioskCredentialPath": "@\"C:\\KioskCredentials\\Keys.json\"",
+  "PlanogramDatabaseUpdateUrl": "http://localhost:5002/api/planogram/dispense/"
 }


### PR DESCRIPTION
- Add Planogram model for the api request payload
-  Use HttpClient to send an asynchronous HTTP PUT request to update the planogram data in the database
- Add PlanogramDatabaseUpdateUrl for api-endpoint in appdettings.json
- Implement logic to read kiosk credentials from a JSON file specified by KioskCredentialPath